### PR TITLE
[wakeup_server] target device logs added to database every midnight

### DIFF
--- a/wakeup_server/homeassistant/homeassistant_client.py
+++ b/wakeup_server/homeassistant/homeassistant_client.py
@@ -127,15 +127,17 @@ class HomeAssistantClient:
                     return Media_Player(state['entity_id'], self)
         return None
 
-    def getLogsPerEntity(self, entity_id):
+    def get_logs_per_entity(self, entity_id):
         today_date = datetime.date.today()
         yesterday_date = today_date - datetime.timedelta(days=1)
-        today_date_complete = str(today_date) + "T12:00:00.000000"  #should be T00:00:00.000000 if midnight is the retrieval time
-        yesterday_date_complete = str(yesterday_date) + "T12:00:00.000000" #should be T00:00:00.000000 
+        today_date_complete = str(today_date) + "T00:00:00.000000"  #should be T00:00:00.000000 if midnight is the retrieval time
+        yesterday_date_complete = str(yesterday_date) + "T00:00:00.000000" #should be T00:00:00.000000 
         request_string = "history/period/" + yesterday_date_complete + "?filter_entity_id=" + str(entity_id) + "&end_time=" + today_date_complete
         data = self._make_request(request_string, method='get')
-        day_usage_data = data[0]
-
+        if(len(data) > 0):
+            day_usage_data = data[0]
+        else:
+            return yesterday_date, 0, '00:00:00.0', '00:00:00.0', '24:00:00.0'
         number_of_toggles = 0
         for entry in day_usage_data:
             if(entry['state'] != "unavailable"):
@@ -162,9 +164,12 @@ class HomeAssistantClient:
         if(start_time != None):
             on_time = datetime.datetime.fromisoformat(today_date_complete + "+00:00") - datetime.datetime.fromisoformat(start_time)
             total_on_time.append(on_time)
-        total_on_time_result = total_on_time[0]
-        for i in range(1, len(total_on_time)):
-            total_on_time_result += total_on_time[i]
+        if(len(total_on_time) > 0):
+            total_on_time_result = total_on_time[0]
+            for i in range(1, len(total_on_time)):
+                total_on_time_result += total_on_time[i]
+        else:
+            total_on_time_result = '0:00:00.000000'
         print("Total on time:" , total_on_time_result)
         
         total_off_time = []
@@ -187,9 +192,12 @@ class HomeAssistantClient:
         if(start_time != None):
             off_time = datetime.datetime.fromisoformat(today_date_complete + "+00:00") - datetime.datetime.fromisoformat(start_time)
             total_off_time.append(off_time)
-        total_off_time_result = total_off_time[0]
-        for i in range(1, len(total_off_time)):
-            total_off_time_result += total_off_time[i]
+        if(len(total_off_time) > 0):
+            total_off_time_result = total_off_time[0]
+            for i in range(1, len(total_off_time)):
+                total_off_time_result += total_off_time[i]
+        else:
+            total_off_time_result = '0:00:00.000000'
         print("Total off time:" , total_off_time_result)
 
         total_unavailable_time = []
@@ -212,12 +220,15 @@ class HomeAssistantClient:
         if(start_time != None):
             unavailable_time = datetime.datetime.fromisoformat(today_date_complete + "+00:00") - datetime.datetime.fromisoformat(start_time)
             total_unavailable_time.append(unavailable_time)
-        total_unavailable_time_result = total_unavailable_time[0]
-        for i in range(1, len(total_unavailable_time)):
-            total_unavailable_time_result += total_unavailable_time[i]
+        if(len(total_unavailable_time) > 0):
+            total_unavailable_time_result = total_unavailable_time[0]
+            for i in range(1, len(total_unavailable_time)):
+                total_unavailable_time_result += total_unavailable_time[i]
+        else:
+            total_unavailable_time_result = '0:00:00.000000'
         print("Total unavailable time:" , total_unavailable_time_result)
 
-        return today_date_complete, number_of_toggles, total_on_time_result, total_off_time_result, total_unavailable_time_result
+        return yesterday_date, number_of_toggles, str(total_on_time_result), str(total_off_time_result), str(total_unavailable_time_result)
 
 
 

--- a/wakeup_server/log_scheduler.py
+++ b/wakeup_server/log_scheduler.py
@@ -1,0 +1,23 @@
+from apscheduler.schedulers.background import BackgroundScheduler
+from models.target_devices import TargetDevice
+
+class LogScheduler:
+    def __init__(self, app):
+        self.scheduler = BackgroundScheduler()
+        self.app = app
+
+    def add_target_device_logs_to_db(self):
+        with self.app.app_context():
+            devices = TargetDevice.find_all()
+            for device in devices:
+                device.log_device_data()
+
+    def start_logging(self):
+        self.scheduler.add_job(self.add_target_device_logs_to_db, 'cron', hour=0, minute=0)
+
+    def start(self):
+        if not self.scheduler.running:
+            self.scheduler.start()
+        else:
+            print("Scheduler is already running")
+

--- a/wakeup_server/models/target_device_logs.py
+++ b/wakeup_server/models/target_device_logs.py
@@ -1,0 +1,35 @@
+from db import db
+from sqlalchemy import Column, Uuid, Integer, Date, String
+import uuid
+
+class TargetDeviceLogs(db.Model):
+  __tablename__ = 'target_device_logs'
+  
+  id = Column(Uuid, primary_key=True)
+  target_device = Column(String)
+  day = Column(Date)
+  number_of_toggles = Column(Integer)
+  on_time = Column(String)
+  off_time = Column(String)
+  unavailable_time = Column(String)
+  
+  def __init__(self, target_device, day, number_of_toggles, on_time, off_time, unavailable_time):
+    self.id = uuid.uuid4()
+    self.target_device = target_device
+    self.day = day
+    self.number_of_toggles = number_of_toggles
+    self.on_time = on_time
+    self.off_time = off_time
+    self.unavailable_time = unavailable_time
+
+  @staticmethod
+  def info(target_device, day, number_of_toggles, on_time, off_time, unavailable_time):
+    new_log = TargetDeviceLogs(target_device, day, number_of_toggles, on_time, off_time, unavailable_time)
+    try:
+      db.session.add(new_log)
+      db.session.commit()
+      return True
+    except Exception as e:
+      print(e)
+      db.session.rollback()
+      raise e

--- a/wakeup_server/models/target_devices.py
+++ b/wakeup_server/models/target_devices.py
@@ -5,6 +5,7 @@ from constants import HOMEASSISTANT_OFFLINE_MODE, DATA_FOLDER_PATH
 from sqlalchemy import Column, String, JSON
 from models.triggers_target_map import trigger_target_association
 from db import db
+from models.target_device_logs import TargetDeviceLogs
 
 class TargetDevice(db.Model):
   __tablename__ = 'target_devices'
@@ -76,6 +77,10 @@ class TargetDevice(db.Model):
       return True
     except Exception as e:
       raise e
+    
+  def log_device_data(self):
+    yesterday_date, number_of_toggles, total_on_time, total_off_time, total_unavailable_time = homeassistant_client.get_logs_per_entity(self.matter_id)
+    TargetDeviceLogs.info(self.matter_id, yesterday_date, number_of_toggles, total_on_time, total_off_time, total_unavailable_time)
     
   @staticmethod
   def find_by_id(matter_id):

--- a/wakeup_server/run.py
+++ b/wakeup_server/run.py
@@ -6,6 +6,7 @@ from blueprints.target_devices.target_devices import target_devices_blueprint
 from blueprints.users.users import users_blueprint
 from homeassistant_client import homeassistant_client
 from db import db
+from log_scheduler import LogScheduler
 
 def create_app(url="sqlite:///wakeup.sqlite"):
     app = Flask(__name__)
@@ -34,6 +35,11 @@ def create_app(url="sqlite:///wakeup.sqlite"):
     db.init_app(app)
     with app.app_context():
         db.create_all()
+        
+    logging_scheduler = LogScheduler(app)
+    logging_scheduler.start_logging()
+    logging_scheduler.start()
+    
     return app
 
 


### PR DESCRIPTION
I added the new functionality so that every midnight the usage logs for each target device is added to a new 'target_device_logs' table on the database. The scheduling is done using an instance of a LogScheduler (based on an APScheduler), which is started when the flask application is first run. I also made some fixes to the get_logs_per_entity method.